### PR TITLE
Fix mobile profile description clipping

### DIFF
--- a/src/components/profile-settings-form.jsx
+++ b/src/components/profile-settings-form.jsx
@@ -500,12 +500,12 @@ export function ProfileSettingsForm({ initialProfile }) {
                   value={bio}
                   onChange={(event) => setBio(event.target.value)}
                   rows={4}
-                  className="h-28 min-h-28 max-h-72 rounded-xl bg-white dark:bg-input/30 md:h-36 md:min-h-36 md:rounded-2xl"
+                  className="h-32 min-h-32 max-h-72 rounded-xl bg-white dark:bg-input/30 md:h-36 md:min-h-36 md:rounded-2xl"
                   placeholder={t.profileBioPlaceholder}
                 />
               </Field>
 
-              <div className="sticky bottom-[calc(4rem+env(safe-area-inset-bottom))] z-30 -mx-4 flex justify-end border-t border-zinc-200 bg-white/95 px-4 py-2 backdrop-blur dark:border-border dark:bg-card/95 md:static md:mx-0 md:border-0 md:bg-transparent md:p-0 md:backdrop-blur-none">
+              <div className="-mx-4 flex justify-end border-t border-zinc-200 bg-white px-4 py-2 dark:border-border dark:bg-card md:mx-0 md:border-0 md:bg-transparent md:p-0">
                 <Button
                   type="submit"
                   size="sm"


### PR DESCRIPTION
## What changed
- keep the profile save action in normal mobile document flow so it cannot cover the bio field
- increase the mobile bio field height so four configured rows fit with internal padding
- preserve the existing desktop layout

## Root cause
The mobile save footer was sticky with a permanent bottom-navigation offset. While the keyboard hid the bottom navigation, the footer continued floating over the final textarea lines.

## Validation
- targeted ESLint passed
- 23/23 regression tests passed
- full Next.js 16 production build passed with the supported Webpack builder
- diff checks passed