### PR TITLE
Fix message media uploads and mobile composer

### DIFF
--- a/src/components/messages-thread.jsx
+++ b/src/components/messages-thread.jsx
@@ -1084,7 +1084,7 @@ export function MessagesThread({
             onKeyDown={handleComposerKeyDown}
             placeholder={t.messageInputPlaceholder}
             rows={2}
-            className="h-12 min-h-12 max-h-32 resize-none border-0 bg-transparent px-2 py-1.5 text-base leading-5 shadow-none focus-visible:ring-0 md:h-14 md:min-h-14"
+            className="min-h-16 max-h-32 resize-none overflow-y-auto border-0 bg-transparent px-2 py-2 text-base leading-5 shadow-none [field-sizing:content] focus-visible:ring-0 md:min-h-14"
             maxLength={2000}
             disabled={!isMessagingAvailable || Boolean(blockReason) || isSending}
           />

--- a/src/lib/translations.js
+++ b/src/lib/translations.js
@@ -401,8 +401,7 @@ export const translations = {
     firstMessageSheetDescription:
       "Your conversation will appear in Messages after you send the first message.",
     sendFirstMessage: "Send first message",
-    messageInputPlaceholder:
-      "Write a message about pickup, condition, price, or availability...",
+    messageInputPlaceholder: "Write a message...",
     emojiPickerSoon: "Emoji reactions are coming next.",
     attachMedia: "Add photos or videos",
     mediaAttachmentHelp: "Up to 3 photos or videos, 10 MB each.",
@@ -1281,8 +1280,7 @@ export const translations = {
     firstMessageSheetDescription:
       "Votre conversation apparaîtra dans Messages après l'envoi du premier message.",
     sendFirstMessage: "Envoyer le premier message",
-    messageInputPlaceholder:
-      "Écrivez un message au sujet de la remise, de l'état, du prix ou de la disponibilité...",
+    messageInputPlaceholder: "Écrivez un message…",
     emojiPickerSoon: "Les réactions emoji arrivent à la prochaine étape.",
     attachMedia: "Ajouter des photos ou des vidéos",
     mediaAttachmentHelp: "Jusqu’à 3 photos ou vidéos de 10 Mo chacune.",

--- a/supabase/migrations/20260812145249_fix_message_media_upload_preflight.sql
+++ b/supabase/migrations/20260812145249_fix_message_media_upload_preflight.sql
@@ -1,0 +1,67 @@
+-- Supabase Storage performs an RLS permission probe before streaming a
+-- multipart upload. At that point metadata contains `mimetype` and
+-- `contentLength` (the complete multipart request length), not the final
+-- object `size`. The original reservation policy therefore rejected every
+-- browser upload before Storage could write the file.
+--
+-- Keep the preflight bound to the exact user/path/MIME reservation. The
+-- bucket enforces the per-object 10 MiB limit while streaming, and
+-- consume_message_media_upload_reservation() still compares the persisted
+-- object MIME and exact final size with the reservation before an attachment
+-- can be added to a message.
+
+create or replace function private.message_media_upload_is_reserved(
+  p_storage_path text,
+  p_owner_id text,
+  p_metadata jsonb
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select (select auth.uid()) is not null
+    and p_owner_id = (select auth.uid())::text
+    and exists (
+      select 1
+      from private.message_media_upload_reservations reservation
+      join public.conversations conversation
+        on conversation.id = reservation.conversation_id
+      join public.listings listing on listing.id = conversation.listing_id
+      where reservation.user_id = (select auth.uid())
+        and reservation.storage_path = p_storage_path
+        and reservation.expires_at > now()
+        and not exists (
+          select 1
+          from private.message_media_account_retirements retirement
+          where retirement.user_id = reservation.user_id
+        )
+        and reservation.mime_type = lower(coalesce(p_metadata ->> 'mimetype', ''))
+        and listing.status = 'active'
+        and (
+          conversation.buyer_id = (select auth.uid())
+          or conversation.seller_id = (select auth.uid())
+        )
+        and not exists (
+          select 1
+          from public.blocked_users blocked
+          where (
+            blocked.blocker_user_id = conversation.buyer_id
+            and blocked.blocked_user_id = conversation.seller_id
+          )
+          or (
+            blocked.blocker_user_id = conversation.seller_id
+            and blocked.blocked_user_id = conversation.buyer_id
+          )
+        )
+    );
+$$;
+
+revoke all on function private.message_media_upload_is_reserved(text, text, jsonb)
+  from public, anon, authenticated, service_role;
+grant execute on function private.message_media_upload_is_reserved(text, text, jsonb)
+  to authenticated;
+
+comment on function private.message_media_upload_is_reserved(text, text, jsonb) is
+  'Authorizes the Storage preflight for an exact active message-media reservation; final size and MIME are revalidated when the attachment is created.';

--- a/tests/message-media-reservations.test.mjs
+++ b/tests/message-media-reservations.test.mjs
@@ -14,8 +14,16 @@ const reservationMigrationUrl = new URL(
   "../supabase/migrations/20260812112419_enforce_message_media_reservations.sql",
   import.meta.url,
 );
+const attachmentMigrationUrl = new URL(
+  "../supabase/migrations/20260812102614_add_message_media_attachments.sql",
+  import.meta.url,
+);
 const storagePolicyGrantMigrationUrl = new URL(
   "../supabase/migrations/20260812142916_grant_message_media_storage_policy_schema_usage.sql",
+  import.meta.url,
+);
+const storagePreflightMigrationUrl = new URL(
+  "../supabase/migrations/20260812145249_fix_message_media_upload_preflight.sql",
   import.meta.url,
 );
 const accountDeleteRouteUrl = new URL("../src/app/api/account/delete/route.js", import.meta.url);
@@ -72,6 +80,18 @@ test("authenticated Storage policy callers can resolve only the reserved-upload 
   assert.match(sql, /grant usage on schema private to authenticated/i);
   assert.doesNotMatch(sql, /grant (select|insert|update|delete|all) on/i);
   assert.doesNotMatch(sql, /grant execute on all functions/i);
+});
+
+test("Storage preflight validates reservation MIME without requiring unavailable final size", async () => {
+  const preflightSql = await readFile(storagePreflightMigrationUrl, "utf8");
+  const reservationSql = await readFile(reservationMigrationUrl, "utf8");
+  const attachmentSql = await readFile(attachmentMigrationUrl, "utf8");
+
+  assert.match(preflightSql, /reservation\.mime_type\s*=\s*lower\(coalesce\(p_metadata ->> 'mimetype'/i);
+  assert.doesNotMatch(preflightSql, /p_metadata ->> 'size'/i);
+  assert.match(reservationSql, /object\.metadata ->> 'mimetype'[\s\S]*reservation\.mime_type/i);
+  assert.match(reservationSql, /object\.metadata ->> 'size'[\s\S]*reservation\.size_bytes/i);
+  assert.match(attachmentSql, /file_size_limit,[\s\S]*allowed_mime_types/i);
 });
 
 test("account deletion strictly retires owned reservations before auth deletion", async () => {


### PR DESCRIPTION
## What changed

- fixes Supabase Storage preflight authorization for reserved message-media uploads
- keeps exact path, owner, participant, active-listing, block, and MIME checks in RLS
- retains the bucket 10 MiB limit and exact persisted MIME/size validation at attachment creation
- prevents the mobile message composer placeholder and typed text from clipping
- adds a regression test for the actual Supabase `{ mimetype, contentLength }` preflight shape

## Root cause

Supabase Storage probes INSERT permission before streaming multipart uploads. The probe metadata contains `mimetype` and `contentLength`; the policy required a final `size` field that exists only after storage completes, so every real upload failed RLS.

## Validation

- `npm run test:security` (25/25)
- targeted ESLint
- `next build --webpack`
- live SQL preflight: valid reservation accepted; wrong MIME and wrong path rejected
- Supabase migration applied and listed on the connected production project
