### PR TITLE
Repair Toronto school Auth hook runtime

### DIFF
--- a/supabase/migrations/20260812233338_enforce_toronto_school_signup_hook.sql
+++ b/supabase/migrations/20260812233338_enforce_toronto_school_signup_hook.sql
@@ -40,7 +40,7 @@ set search_path = ''
 as $$
 declare
   normalized_email text := pg_catalog.lower(pg_catalog.btrim(
-    pg_catalog.coalesce(event -> 'user' ->> 'email', '')
+    coalesce(event -> 'user' ->> 'email', '')
   ));
   school_name text;
 begin

--- a/supabase/migrations/20260813011731_fix_toronto_school_auth_hook_runtime.sql
+++ b/supabase/migrations/20260813011731_fix_toronto_school_auth_hook_runtime.sql
@@ -1,0 +1,46 @@
+-- COALESCE is SQL syntax rather than a pg_catalog function. Recreate the hook
+-- with an unqualified COALESCE expression so it executes under the empty
+-- search_path used by Supabase Auth.
+create or replace function public.before_user_created_enforce_toronto_school(event jsonb)
+returns jsonb
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  normalized_email text := pg_catalog.lower(pg_catalog.btrim(
+    coalesce(event -> 'user' ->> 'email', '')
+  ));
+  school_name text;
+begin
+  if normalized_email !~ '^[^@[:space:]]+@[^@[:space:]]+$' then
+    return pg_catalog.jsonb_build_object(
+      'error',
+      pg_catalog.jsonb_build_object(
+        'http_code', 403,
+        'message', 'Use a valid Toronto school email from a supported school domain.'
+      )
+    );
+  end if;
+
+  school_name := private.toronto_school_name_for_email(normalized_email);
+
+  if school_name is not null then
+    return '{}'::jsonb;
+  end if;
+
+  return pg_catalog.jsonb_build_object(
+    'error',
+    pg_catalog.jsonb_build_object(
+      'http_code', 403,
+      'message', 'Use a valid Toronto school email from a supported school domain.'
+    )
+  );
+end;
+$$;
+
+revoke all on function public.before_user_created_enforce_toronto_school(jsonb)
+from public, anon, authenticated, service_role, supabase_auth_admin;
+
+grant execute on function public.before_user_created_enforce_toronto_school(jsonb)
+to supabase_auth_admin;

--- a/tests/auth-account-security.test.mjs
+++ b/tests/auth-account-security.test.mjs
@@ -23,9 +23,13 @@ const expectedSchoolDomains = [
 ];
 
 test("Auth creation hook enforces the exact normalized Toronto school allowlist", async () => {
-  const [hookSql, retiredHookAclSql, clientAllowlist] = await Promise.all([
+  const [hookSql, hookRuntimeFixSql, retiredHookAclSql, clientAllowlist] = await Promise.all([
     readFile(
       repoFile("supabase/migrations/20260812233338_enforce_toronto_school_signup_hook.sql"),
+      "utf8",
+    ),
+    readFile(
+      repoFile("supabase/migrations/20260813011731_fix_toronto_school_auth_hook_runtime.sql"),
       "utf8",
     ),
     readFile(
@@ -44,6 +48,12 @@ test("Auth creation hook enforces the exact normalized Toronto school allowlist"
   assert.deepEqual(migrationDomains, expectedSchoolDomains);
   assert.deepEqual(clientDomains, expectedSchoolDomains);
   assert.match(hookSql, /lower\(pg_catalog\.btrim[\s\S]*event -> 'user' ->> 'email'/i);
+  assert.doesNotMatch(hookSql, /pg_catalog\.coalesce/i);
+  assert.match(
+    hookRuntimeFixSql,
+    /coalesce\(event -> 'user' ->> 'email', ''\)/i,
+  );
+  assert.doesNotMatch(hookRuntimeFixSql, /pg_catalog\.coalesce/i);
   assert.match(
     hookSql,
     /school_name := private\.toronto_school_name_for_email\(normalized_email\)/i,


### PR DESCRIPTION
## Summary
- repair the Before User Created hook runtime expression under an empty search path
- preserve the additive production migration for already-applied databases
- add regression assertions for the invalid schema-qualified COALESCE form

## Validation
- production hook invocation accepts a George Brown address
- production hook invocation rejects example.com and malformed multi-@ addresses
- npm run test:security (64/64)
- targeted ESLint and git diff --check

This hotfix follows PR #72 after a live non-mutating invocation caught the SQL runtime error.